### PR TITLE
Show sparkles at tap location

### DIFF
--- a/HelloBun/ContentView.swift
+++ b/HelloBun/ContentView.swift
@@ -7,11 +7,13 @@
 
 import SwiftUI
 import AVFAudio
+import SpriteKit
 
 struct ContentView: View {
     @State private var message = "Hello, my Bunny 💛"
     @State var boopCount = 0
     @State private var audioPlayer: AVAudioPlayer!
+    @StateObject private var scene = sparkleScene()
     var body: some View {
         VStack(spacing: 20) {
             Text(message)
@@ -22,15 +24,26 @@ struct ContentView: View {
                 .font(.largeTitle)
                 .padding()
             
-            Image("BunnyBean")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 200, height: 200)
-                .onTapGesture {
-                    boopCount += 1
-                    message = "Bunny Booped! 💖🐰"
-                    playBoopSound()
-                }
+            ZStack {
+                Image("BunnyBean")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 200, height: 200)
+                SpriteView(scene: scene)
+                    .frame(width: 200, height: 200)
+                    .allowsTransparency(true)
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onEnded { value in
+                                let location = CGPoint(x: value.location.x,
+                                                      y: scene.size.height - value.location.y)
+                                boopCount += 1
+                                message = "Bunny Booped! 💖🐰"
+                                playBoopSound()
+                                scene.emitSparkle(at: location)
+                            }
+                    )
+            }
 
 
             Button("Boop") {


### PR DESCRIPTION
## Summary
- overlay a SpriteKit view on the bunny image
- capture tap location with a zero-distance DragGesture
- emit the sparkle emitter at that location

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874394bff30832c868adeb26c3d448b